### PR TITLE
Fix modal visibility toggling

### DIFF
--- a/script.js
+++ b/script.js
@@ -597,6 +597,7 @@ function endGame(winner) {
   cancelAnimationFrame(state.loopHandle);
   const rewards = applyRewards(winner);
   modal.hidden = false;
+  modal.classList.add("is-open");
   modalMessage.textContent = winner === "player" ? "Vous remportez la couronne !" : "La tour a cédé. Retentez votre chance.";
   modalTitle.textContent = winner === "player" ? "Victoire !" : "Défaite";
   rewardMessage.textContent = rewards.text;
@@ -608,6 +609,7 @@ function endGame(winner) {
 
 function toggleModal(open) {
   modal.hidden = !open;
+  modal.classList.toggle("is-open", open);
   if (!open) {
     startGameBtn.focus();
   }

--- a/styles.css
+++ b/styles.css
@@ -457,11 +457,15 @@ nav {
 .modal {
   position: fixed;
   inset: 0;
-  display: grid;
+  display: none;
   place-items: center;
   background: rgba(15, 23, 42, 0.8);
   backdrop-filter: blur(8px);
   padding: 2rem;
+}
+
+.modal.is-open {
+  display: grid;
 }
 
 .modal-content {


### PR DESCRIPTION
## Summary
- ensure the end-game modal applies an `.is-open` state class when shown and removes it when hidden
- keep the modal display off by default and only render it when `.is-open` is present

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4710859cc8329a8fc8766cb79e5cb